### PR TITLE
Allowing org user to bypass whitelist check

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ We thank you again for helping ensure the security of Savage by responsibly repo
 [GitHub]  <<<(Request details about the PR using the PR's HEAD commit's SHA)<<<  [Savage]
 [GitHub]  >>>(Response with details about the PR)>>>  [Savage]
 * Savage checks list of files modified by the PR against the whitelist
-  * If any files are outside of the whitelist, stop further processing.
+  * If any files are outside of the whitelist, stop further processing, unless the user submitting the PR is a public member of the organization.
 
 [GitHub]  <<<(Request for Git data for the PR's HEAD commit via its SHA)<<<  [Savage]
 [GitHub]  >>>(Response with Git data for the PR's HEAD commit)>>>  [Savage]

--- a/src/main/scala/com/getbootstrap/savage/server/PullRequestEventHandler.scala
+++ b/src/main/scala/com/getbootstrap/savage/server/PullRequestEventHandler.scala
@@ -85,6 +85,7 @@ class PullRequestEventHandler(
       implicit val prNum = pr.number
       val bsBase = pr.getBase
       val prHead = pr.getHead
+      val prUser = new GitHubUser(pr.getUser.getLogin)
       val destinationRepo = bsBase.getRepo.repositoryId
       destinationRepo match {
         case None => log.error(s"Received event from GitHub about irrelevant repository with unsafe name")
@@ -106,7 +107,7 @@ class PullRequestEventHandler(
                       }
                       case Success(affectedFiles) => {
                         log.debug("Files affected by {}: {}", prNum, affectedFiles)
-                        if (areSafe(affectedFiles)) {
+                        if (areSafe(affectedFiles) || isTrusted(prUser)) {
                           if (areInteresting(affectedFiles)) {
                             logPrInfo(s"Requesting build for safe & interesting PR")
                             pusher ! PullRequestPushRequest(


### PR DESCRIPTION
Implementation of #30.  To be honest, I've never written in Scala.  There may be a better way to create a `GitHubUser` from a `User`, which is what type the `isTrusted` method expects.