### PR TITLE
Switch to non-hierarchical GitHub commit status context string

### DIFF
--- a/src/main/scala/com/getbootstrap/savage/github/commit_status/Status.scala
+++ b/src/main/scala/com/getbootstrap/savage/github/commit_status/Status.scala
@@ -3,7 +3,7 @@ package com.getbootstrap.savage.github.commit_status
 import org.eclipse.egit.github.core.{CommitStatus => RawCommitStatus}
 
 object Status {
-  private val context = "continuous-integration/savage"
+  private val context = "savage"
 }
 trait Status {
   def description: String


### PR DESCRIPTION
For brevity's sake, because GitHub uses a truncating fixed-width field to display statuses.
h/t to @houndci for the idea.