### PR TITLE
Move HmacSha1 from util package to crypto package

### DIFF
--- a/src/main/scala/com/getbootstrap/savage/crypto/HmacSha1.scala
+++ b/src/main/scala/com/getbootstrap/savage/crypto/HmacSha1.scala
@@ -1,9 +1,10 @@
-package com.getbootstrap.savage.util
+package com.getbootstrap.savage.crypto
 
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 import java.security.{NoSuchAlgorithmException, InvalidKeyException, SignatureException}
 import java.security.MessageDigest
+import com.getbootstrap.savage.util.HexByteArray
 
 object HmacSha1 {
   private val HmacSha1Algorithm = "HmacSHA1"

--- a/src/main/scala/com/getbootstrap/savage/server/HubSignatureDirectives.scala
+++ b/src/main/scala/com/getbootstrap/savage/server/HubSignatureDirectives.scala
@@ -3,7 +3,8 @@ package com.getbootstrap.savage.server
 import scala.util.{Try,Success,Failure}
 import spray.routing.{Directive1, MalformedHeaderRejection, MalformedRequestContentRejection, ValidationRejection}
 import spray.routing.directives.{BasicDirectives, HeaderDirectives, RouteDirectives, MarshallingDirectives}
-import com.getbootstrap.savage.util.{HmacSha1,Utf8ByteArray}
+import com.getbootstrap.savage.crypto.HmacSha1
+import com.getbootstrap.savage.util.Utf8ByteArray
 
 trait HubSignatureDirectives  {
   import BasicDirectives.provide


### PR DESCRIPTION
For more logical organization.
HmacSha1 is used to verify the integrity and authenticity of requests from GitHub.